### PR TITLE
Parent placeables under map

### DIFF
--- a/Gates of Mansole/Assets/Scripts/Controllers/WorldController.cs
+++ b/Gates of Mansole/Assets/Scripts/Controllers/WorldController.cs
@@ -203,7 +203,8 @@ public class WorldController : MonoBehaviour {
 
 			// Place the placeables
 			foreach(WaveList._placeable pl in currentLevel.GetComponent<WaveList>().placeables) {
-				Instantiate(Placeables[pl.num], new Vector3(pl.x, pl.y), Quaternion.identity);
+				Placeables[pl.num] = Instantiate(Placeables[pl.num], new Vector3(pl.x, pl.y), Quaternion.identity) as GameObject;
+				Placeables[pl.num].transform.parent = map.transform;
 			}
 
             Player.spiritShards = Player.totalShards = currentLevel.GetComponent<WaveList>().startShards;


### PR DESCRIPTION
From Trello list: In Progress (0.1.0) -  [BUG] Unity : Put placeables under map as parent (so they shake with earthquake)